### PR TITLE
Remove Lodash and Bluebird to decrease output size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/semisleep/simple-vue-validator#readme",
   "dependencies": {
-    "bluebird": "^3.4.6",
-    "lodash": "^4.17.2"
+    "deep-equal": "^1.0.1",
+    "es6-promise": "^4.0.5"
   },
   "devDependencies": {
     "autoprefixer": "^6.5.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('es6-promise/auto');
+
 var ValidationBag = require('./validation-bag');
 var Rule = require('./rule');
 var Validator = require('./validator');

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _ = require('lodash/core');
 var omit = require('lodash/omit');
 var debounce = require('lodash/debounce');
-var Promise = require('bluebird');
+var Promise = require('es6-promise').Promise;
+var utils = require('./utils');
 var ValidationBag = require('./validation-bag');
 
 var mixin = {
@@ -17,7 +17,7 @@ var mixin = {
     // generate validate methods and watch properties change for validators
     var validators = this.$options.validators;
     if (validators) {
-      _.keys(validators).forEach(function (key) {
+      Object.keys(validators).forEach(function (key) {
         var properties = key.split(',');
         properties = properties.map(function (property) {
           return property.trim();
@@ -27,7 +27,7 @@ var mixin = {
         }, this);
         var validator = validators[key];
         var options = {};
-        if (!_.isFunction(validator)) {
+        if (!utils.isFunction(validator)) {
           options = omit(validator, 'validator');
           validator = validator.validator;
         }
@@ -101,7 +101,7 @@ var mixin = {
   methods: {
     $validate: function () {
       var validateMethods = this.$options.validateMethods;
-      if (_.isEmpty(validateMethods)) {
+      if (utils.isEmpty(validateMethods)) {
         return Promise.resolve(true);
       } else {
         return Promise
@@ -124,7 +124,7 @@ function generateGetter(vm, property) {
   return function () {
     var value = vm;
     for (var i = 0; i < names.length; i++) {
-      if (_.isNull(value) || _.isUndefined(value)) {
+      if (utils.isNull(value) || utils.isUndefined(value)) {
         break;
       }
       value = value[names[i]];
@@ -151,14 +151,14 @@ function cache(validator, option) {
     }
     var args = Array.prototype.slice.call(arguments);
     var cachedResult = findInCache(cache, args);
-    if (!_.isUndefined(cachedResult)) {
+    if (!utils.isUndefined(cachedResult)) {
       return cachedResult;
     }
     var result = validator.apply(this, args);
-    if (!_.isUndefined(result)) {
+    if (!utils.isUndefined(result)) {
       if (result.then) {
         return result.tab(function (promiseResult) {
-          if (!_.isUndefined(promiseResult)) {
+          if (!utils.isUndefined(promiseResult)) {
             if (option !== 'all') {
               cache.splice(0, cache.length);
             }
@@ -178,9 +178,9 @@ function cache(validator, option) {
 
 function findInCache(cache, args) {
   var items = cache.filter(function (item) {
-    return _.isEqual(args, item.args);
+    return utils.isEqual(args, item.args);
   });
-  if (!_.isEmpty(items)) {
+  if (!utils.isEmpty(items)) {
     return items[0].result;
   }
 }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var omit = require('lodash/omit');
-var debounce = require('lodash/debounce');
 var Promise = require('es6-promise').Promise;
 var utils = require('./utils');
 var ValidationBag = require('./validation-bag');
@@ -28,7 +26,7 @@ var mixin = {
         var validator = validators[key];
         var options = {};
         if (!utils.isFunction(validator)) {
-          options = omit(validator, 'validator');
+          options = utils.omit(validator, 'validator');
           validator = validator.validator;
         }
         if (options.cache) {
@@ -66,7 +64,7 @@ var mixin = {
             }
             return validateMethod.apply(this, arguments);
           }.bind(this);
-          var debouncedValidateMethod = debounce(decoratedValidateMethod, parseInt(options.debounce));
+          var debouncedValidateMethod = utils.debounce(decoratedValidateMethod, parseInt(options.debounce));
           var field = properties[0];
           validateMethodForWatch = function () {
             // eagerly resetting passed flag if debouncing is used.

--- a/src/rule.js
+++ b/src/rule.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash/core');
 var utils = require('./utils');
 
 function Rule() {
@@ -56,7 +55,7 @@ Rule.prototype.float = function () {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseFloat(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeFloat);
     }
   }
@@ -67,7 +66,7 @@ Rule.prototype.integer = function () {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseInt(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeInteger);
     }
   }
@@ -78,7 +77,7 @@ Rule.prototype.lessThan = function (bound) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseFloat(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeNumber);
     } else if (number >= bound) {
       this._messages.push(utils.format(utils.templates.mustLessThan, bound));
@@ -91,7 +90,7 @@ Rule.prototype.lessThanOrEqualTo = function (bound) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseFloat(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeNumber);
     } else if (number > bound) {
       this._messages.push(utils.format(utils.templates.mustLessThanOrEqualTo, bound));
@@ -104,7 +103,7 @@ Rule.prototype.greaterThan = function (bound) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseFloat(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeNumber);
     } else if (number <= bound) {
       this._messages.push(utils.format(utils.templates.mustGreaterThan, bound));
@@ -117,7 +116,7 @@ Rule.prototype.greaterThanOrEqualTo = function (bound) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseFloat(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeNumber);
     } else if (number < bound) {
       this._messages.push(utils.format(utils.templates.mustGreaterThanOrEqualTo, bound));
@@ -130,7 +129,7 @@ Rule.prototype.between = function (lowBound, highBound) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
     var number = parseFloat(value);
-    if (_.isNaN(number)) {
+    if (utils.isNaN(number)) {
       this._messages.push(utils.templates.mustBeNumber);
     } else if (number < lowBound || number > highBound) {
       this._messages.push(utils.format(utils.templates.mustBetween, lowBound, highBound));
@@ -142,7 +141,7 @@ Rule.prototype.between = function (lowBound, highBound) {
 Rule.prototype.size = function (size) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
-    if (_.isArray(value) && value.length != size) {
+    if (utils.isArray(value) && value.length != size) {
       this._messages.push(utils.format(utils.templates.sizeMustBe, size));
     }
   }
@@ -230,7 +229,7 @@ Rule.prototype.match = function (valueToCompare, message) {
 Rule.prototype.regex = function (regex, message) {
   var value = this._checkValue();
   if (!utils.isEmpty(value)) {
-    if (_.isString(regex)) {
+    if (utils.isString(regex)) {
       regex = new RegExp(regex);
     }
     if (!regex.test(value)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,29 @@
 
 var deepEqual = require('deep-equal');
 
+// This implementation of debounce was taken from the blog of David Walsh.
+// See here: https://davidwalsh.name/javascript-debounce-function
+module.exports.debounce = function debounce(func, wait, immediate) {
+  var timeout;
+
+  return function () {
+    var context = this; args = arguments;
+    var later = function () {
+      timeout = null;
+      if (!immediate) {
+        func.apply(context, args);
+      }
+    };
+
+    var callNow = imediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) {
+      func.apply(context, args);
+    }
+  };
+};
+
 module.exports.format = function (template) {
   var args = Array.prototype.slice.call(arguments, 1);
   return template.replace(/{(\d+)}/g, function (match, number) {
@@ -49,6 +72,18 @@ module.exports.isString = function isString(arg) {
 
 module.exports.isUndefined = function isUndefined(arg) {
   return typeof arg === 'undefined';
+};
+
+module.exports.omit = function omit(obj, key) {
+  var result = {};
+
+  for (var name in obj) {
+    if (name !== key) {
+      result[name] = obj[name];
+    }
+  }
+
+  return result;
 };
 
 module.exports.templates = require('./templates');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,6 @@
 'use strict';
 
-var _ = require('lodash/core');
-
-module.exports.isEmpty = function (value) {
-  if (_.isArray(value)) {
-    return !value.length;
-  } else if (value === undefined || value === null) {
-    return true;
-  } else {
-    return !String(value).trim().length;
-  }
-};
+var deepEqual = require('deep-equal');
 
 module.exports.format = function (template) {
   var args = Array.prototype.slice.call(arguments, 1);
@@ -19,4 +9,47 @@ module.exports.format = function (template) {
   });
 };
 
+module.exports.isArray = function isArray(arg) {
+  if (typeof Array.isArray === 'function') {
+    return Array.isArray(arg);
+  }
+
+  return Object.prototype.toString.call(arg) === '[object Array]';
+};
+
+module.exports.isEmpty = function (value) {
+  if (isArray(value)) {
+    return !value.length;
+  } else if (value === undefined || value === null) {
+    return true;
+  } else {
+    return !String(value).trim().length;
+  }
+};
+
+module.exports.isEqual = function isEqual(o1, o2) {
+  return deepEqual(o1, o2);
+};
+
+module.exports.isFunction = function isFunction(arg) {
+  return typeof arg === 'function';
+};
+
+module.exports.isNaN = function isNaN(arg) {
+  return arg !== arg;
+};
+
+module.exports.isNull = function isNull(arg) {
+  return arg === null;
+};
+
+module.exports.isString = function isString(arg) {
+  return typeof arg === 'string' || arg instanceof String;
+};
+
+module.exports.isUndefined = function isUndefined(arg) {
+  return typeof arg === 'undefined';
+};
+
 module.exports.templates = require('./templates');
+

--- a/src/validation-bag.js
+++ b/src/validation-bag.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var _ = require('lodash/core');
-var Promise = require('bluebird');
+var Promise = require('es6-promise').Promise;
 var Vue = require('vue');
+
+var utils = require('./utils');
 
 function ValidationBag() {
   this.sessionId = 0; // async validator will check this before adding error
@@ -21,7 +22,7 @@ ValidationBag.prototype.addError = function (field, message) {
 };
 
 ValidationBag.prototype.removeErrors = function (field) {
-  if (_.isUndefined(field)) {
+  if (utils.isUndefined(field)) {
     this.errors = [];
   } else {
     this.errors = this.errors.filter(function (e) {
@@ -31,12 +32,12 @@ ValidationBag.prototype.removeErrors = function (field) {
 };
 
 ValidationBag.prototype.hasError = function (field) {
-  return _.isUndefined(field) ? !!this.errors.length : !!this.firstError(field);
+  return utils.isUndefined(field) ? !!this.errors.length : !!this.firstError(field);
 };
 
 ValidationBag.prototype.firstError = function (field) {
   for (var i = 0; i < this.errors.length; i++) {
-    if (_.isUndefined(field) || this.errors[i].field === field) {
+    if (utils.isUndefined(field) || this.errors[i].field === field) {
       return this.errors[i].message;
     }
   }
@@ -46,7 +47,7 @@ ValidationBag.prototype.firstError = function (field) {
 ValidationBag.prototype.allErrors = function (field) {
   return this.errors
     .filter(function (e) {
-      return _.isUndefined(field) || e.field === field;
+      return utils.isUndefined(field) || e.field === field;
     })
     .map(function (e) {
       return e.message;
@@ -54,7 +55,7 @@ ValidationBag.prototype.allErrors = function (field) {
 };
 
 ValidationBag.prototype.countErrors = function (field) {
-  return _.isUndefined(field) ? this.errors.length : this.errors.filter(function (e) {
+  return utils.isUndefined(field) ? this.errors.length : this.errors.filter(function (e) {
     return field === e.field;
   }).length;
 };
@@ -67,7 +68,7 @@ ValidationBag.prototype.setValidating = function (field, id) {
   var existingValidatingRecords = this.validatingRecords.filter(function (validating) {
     return validating.field === field && validating.id === id;
   });
-  if (!_.isEmpty(existingValidatingRecords)) {
+  if (!utils.isEmpty(existingValidatingRecords)) {
     throw new Error('Validating id already set: ' + id);
   }
   this.validatingRecords.push({field: field, id: id});
@@ -81,7 +82,7 @@ ValidationBag.prototype.resetValidating = function (field, id) {
   }
 
   function idMatched(validating) {
-    return _.isUndefined(id) ? true : (validating.id === id);
+    return utils.isUndefined(id) ? true : (validating.id === id);
   }
 
   var hasMore = true;
@@ -103,13 +104,13 @@ ValidationBag.prototype.resetValidating = function (field, id) {
 
 ValidationBag.prototype.isValidating = function (field, id) {
   function idMatched(validating) {
-    return _.isUndefined(id) ? true : (validating.id === id);
+    return utils.isUndefined(id) ? true : (validating.id === id);
   }
 
   var existingValidatingRecords = this.validatingRecords.filter(function (validating) {
-    return (_.isUndefined(field) || validating.field === field) && idMatched(validating);
+    return (utils.isUndefined(field) || validating.field === field) && idMatched(validating);
   });
-  return !_.isEmpty(existingValidatingRecords);
+  return !utils.isEmpty(existingValidatingRecords);
 };
 
 ValidationBag.prototype.setPassed = function (field) {
@@ -146,7 +147,7 @@ function setValue(records, field) {
   var existingRecords = records.filter(function (record) {
     return record.field === field;
   });
-  if (!_.isEmpty(existingRecords)) {
+  if (!utils.isEmpty(existingRecords)) {
     existingRecords[0].value = true;
   } else {
     records.push({field: field, value: true});
@@ -161,7 +162,7 @@ function resetValue(records, field) {
   var existingRecords = records.filter(function (record) {
     return record.field === field;
   });
-  if (!_.isEmpty(existingRecords)) {
+  if (!utils.isEmpty(existingRecords)) {
     existingRecords[0].value = false;
   }
 }
@@ -170,7 +171,7 @@ function isValueSet(records, field) {
   var existingRecords = records.filter(function (record) {
     return record.field === field;
   });
-  return !_.isEmpty(existingRecords) && existingRecords[0].value;
+  return !utils.isEmpty(existingRecords) && existingRecords[0].value;
 }
 
 ValidationBag.prototype.reset = function () {
@@ -194,7 +195,7 @@ ValidationBag.prototype.setError = function (field, message) {
   this.removeErrors(field);
   this.resetPassed(field);
 
-  var messages = _.isArray(message) ? message : [message];
+  var messages = utils.isArray(message) ? message : [message];
   var addMessages = function (messages) {
     var hasError = false;
     messages.forEach(function (message) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var _ = require('lodash/core');
 var utils = require('./utils');
 var Rule = require('./rule');
 
 var Validator = {};
 
 // clone methods from Rule to Validator
-_.keys(Rule.prototype).forEach(function (methodName) {
+Object.keys(Rule.prototype).forEach(function (methodName) {
   Validator[methodName] = function () {
     var rule = new Rule();
     return rule[methodName].apply(rule, arguments);
@@ -23,7 +22,9 @@ Validator.isEmpty = utils.isEmpty;
 Validator.format = utils.format;
 
 Validator.extendTemplates = function(newTemplate) {
-  _.extend(utils.templates, newTemplate);
+  Object.keys(newTemplates).forEach(function (key) {
+    utils.templates[key] = newTemplate[key];
+  });
 };
 
 module.exports = Validator;


### PR DESCRIPTION
simple-vue-validator requires both Lodash and Bluebird. According to my
Webpack dev build, Lodash@0.9.9 is 211.3k and Bluebird@3.4.7 is 173.6k.

Since both of these libraries are used minimally in
simple-vue-validator, it makes sense to replace them. This will avoid
forcing both Lodash and Bluebird onto developers who don't use them
otherwise in their project.

Bluebird:

This PR replace Bluebird with the much smaller es6-promise library.
es6-promise weighs in at 27.9k uncompressed and unminified.

es6-promise is limited in scope, which is how it can be so small. If a
feature is needed that es6-promise doesn't provide, then Bluebird can be
reconsidered. As it stands, es6-promise appears to meet the needs of
simple-vue-validator.

Lodash:

Usage of Lodash in simple-vue-validator is limited to a handful of
functions. These functions are simple enough that we can write our own
definitions, which I've done and included in `src/utils.js`.

`_.keys` was replaced with `Object.keys` which is supported by IE9+ and
all recent versions of other major browsers.

See
[here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Browser_compatibility)
for more info on `Object.keys` browser compatibility.

`_.extend` was used once to copy the protype of `Rule`. This is a very
simple use case, so I replaced `_.extend` with a simple for loop. If
more functionality is needed, then the
[extend](https://www.npmjs.com/package/extend) NPM package might be a
good option.

See `src/utils.js` for other function definitions.

Hope this helps!